### PR TITLE
feat(follower): 다른 사용자를 팔로우 할 수 있다

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="NonAsciiCharacters" enabled="true" level="INFORMATION" enabled_by_default="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+  </profile>
+</component>

--- a/src/main/java/com/demo/feedsystemdesign/common/exception/ErrorCode.java
+++ b/src/main/java/com/demo/feedsystemdesign/common/exception/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "U_001", "존재하지 않는 사용자입니다."),
 
     POST_CONTENT_TOO_SHORT(400, "P_001", "게시물 내용이 짧습니다."),
-    POST_CONTENT_TOO_LONG(400, "P_002", "게시물 내용이 너무 깁니다"),
+    POST_CONTENT_TOO_LONG(400, "P_002", "게시물 내용이 너무 깁니다."),
+
+    SELF_FOLLOWING(400, "F_001", "자신을 팔로우 할 수 없습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/demo/feedsystemdesign/common/exception/FollowException.java
+++ b/src/main/java/com/demo/feedsystemdesign/common/exception/FollowException.java
@@ -1,0 +1,7 @@
+package com.demo.feedsystemdesign.common.exception;
+
+public class FollowException extends BusinessException {
+    public FollowException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
@@ -1,21 +1,31 @@
 package com.demo.feedsystemdesign.follow.domain;
 
+import com.demo.feedsystemdesign.common.exception.ErrorCode;
+import com.demo.feedsystemdesign.common.exception.FollowException;
+
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.demo.feedsystemdesign.common.exception.ErrorCode.SELF_FOLLOWING;
+
 public class Followers {
 
+    private final Long userId;
     private final List<Long> followers;
 
-    public Followers() {
-        this(new ArrayList<>());
+    public Followers(Long userId) {
+        this(userId, new ArrayList<>());
     }
 
-    public Followers(List<Long> followers) {
+    public Followers(Long userId, List<Long> followers) {
+        this.userId = userId;
         this.followers = followers;
     }
 
     public void add(Long otherUserId) {
+        if (userId.equals(otherUserId)) {
+            throw new FollowException(SELF_FOLLOWING);
+        }
         followers.add(otherUserId);
     }
 
@@ -25,5 +35,9 @@ public class Followers {
 
     public List<Long> findAll() {
         return followers;
+    }
+
+    public Long getUserId() {
+        return userId;
     }
 }

--- a/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
@@ -1,6 +1,5 @@
 package com.demo.feedsystemdesign.follow.domain;
 
-import com.demo.feedsystemdesign.common.exception.ErrorCode;
 import com.demo.feedsystemdesign.common.exception.FollowException;
 
 import java.util.ArrayList;

--- a/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
@@ -1,0 +1,25 @@
+package com.demo.feedsystemdesign.follow.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Followers {
+
+    private final List<Long> followers;
+
+    public Followers() {
+        this(new ArrayList<>());
+    }
+
+    public Followers(List<Long> followers) {
+        this.followers = followers;
+    }
+
+    public void add(Long otherUserId) {
+        followers.add(otherUserId);
+    }
+
+    public boolean contains(Long otherUserId) {
+        return followers.contains(otherUserId);
+    }
+}

--- a/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
@@ -22,4 +22,8 @@ public class Followers {
     public boolean contains(Long otherUserId) {
         return followers.contains(otherUserId);
     }
+
+    public List<Long> findAll() {
+        return followers;
+    }
 }

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -1,0 +1,26 @@
+package com.demo.feedsystemdesign.follow.service;
+
+import com.demo.feedsystemdesign.follow.domain.Followers;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class FollowService {
+
+    Map<Long, Followers> store = new HashMap<>();
+
+    public void follow(Long userId, Long subjectId) {
+        if (store.get(subjectId) == null) {
+            store.put(subjectId, new Followers(subjectId));
+        }
+        Followers followers = store.get(subjectId);
+        followers.add(userId);
+    }
+
+    public List<Long> getFollowers(Long userId) {
+       return store.get(userId).findAll();
+    }
+}

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -21,6 +21,6 @@ public class FollowService {
     }
 
     public List<Long> getFollowers(Long userId) {
-       return store.get(userId).findAll();
+        return store.get(userId).findAll();
     }
 }

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -12,6 +12,7 @@ public class FollowService {
 
     Map<Long, Followers> store = new HashMap<>();
 
+    // TODO: use primitive type
     public void follow(Long userId, Long subjectId) {
         if (store.get(subjectId) == null) {
             store.put(subjectId, new Followers(subjectId));

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -1,19 +1,31 @@
 package com.demo.feedsystemdesign.follow.service;
 
+import com.demo.feedsystemdesign.common.exception.NotFoundException;
 import com.demo.feedsystemdesign.follow.domain.Followers;
+import com.demo.feedsystemdesign.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.demo.feedsystemdesign.common.exception.ErrorCode.USER_NOT_FOUND;
+
 @Service
 public class FollowService {
 
+    private final UserRepository userRepository;
     Map<Long, Followers> store = new HashMap<>();
+
+    public FollowService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     // TODO: use primitive type
     public void follow(Long userId, Long subjectId) {
+        validateExists(userId);
+        validateExists(subjectId);
+
         if (store.get(subjectId) == null) {
             store.put(subjectId, new Followers(subjectId));
         }
@@ -23,5 +35,11 @@ public class FollowService {
 
     public List<Long> getFollowers(Long userId) {
         return store.get(userId).findAll();
+    }
+
+    // TODO: 중복 코드 제거
+    private void validateExists(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
 }

--- a/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
@@ -10,10 +10,20 @@ class FollowersTest {
     @Test
     void 다른_사용자가_팔로우_할_수_있다() {
         Followers followers = new Followers();
-        User user = new User();
+        User other = new User();
 
-        followers.add(user.getId());
+        followers.add(other.getId());
 
-        assertThat(followers.contains(user.getId())).isTrue();
+        assertThat(followers.contains(other.getId())).isTrue();
+    }
+
+    @Test
+    void 팔로워들을_알_수_있다() {
+        Followers followers = new Followers();
+        followers.add(1L);
+        followers.add(2L);
+        followers.add(3L);
+
+        assertThat(followers.findAll()).contains(1L, 2L, 3L);
     }
 }

--- a/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
@@ -1,39 +1,51 @@
 package com.demo.feedsystemdesign.follow.domain;
 
+import com.demo.feedsystemdesign.common.exception.FollowException;
+import com.demo.feedsystemdesign.common.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FollowersTest {
 
     @Test
     void 다른_사용자가_팔로우_할_수_있다() {
-        Followers followers = new Followers();
+        Followers followers = new Followers(1L);
 
-        followers.add(1L);
+        followers.add(2L);
 
-        assertThat(followers.contains(1L)).isTrue();
+        assertThat(followers.contains(2L)).isTrue();
     }
 
     @ParameterizedTest
-    @CsvSource({"1, true", "0, false"})
+    @CsvSource({"2, true", "0, false"})
     void 팔로우_여부를_알_수_있다(Long otherUserId, boolean follows) {
-        Followers followers = new Followers();
+        Followers followers = new Followers(1L);
 
-        followers.add(1L);
+        followers.add(2L);
 
         assertThat(followers.contains(otherUserId)).isEqualTo(follows);
     }
 
     @Test
     void 팔로워들을_알_수_있다() {
-        Followers followers = new Followers();
-        followers.add(1L);
+        Followers followers = new Followers(1L);
         followers.add(2L);
         followers.add(3L);
+        followers.add(4L);
 
-        assertThat(followers.findAll()).contains(1L, 2L, 3L);
+        assertThat(followers.findAll()).contains(2L, 3L, 4L);
+    }
+
+    @Test
+    void 자신을_팔로우_할_수_없다() {
+        Followers followers = new Followers(1L);
+
+        assertThatThrownBy(() -> followers.add(1L))
+                .isInstanceOf(FollowException.class)
+                .hasMessage(ErrorCode.SELF_FOLLOWING.getMessage());
     }
 }

--- a/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
@@ -1,7 +1,8 @@
 package com.demo.feedsystemdesign.follow.domain;
 
-import com.demo.feedsystemdesign.user.domain.User;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,11 +11,20 @@ class FollowersTest {
     @Test
     void 다른_사용자가_팔로우_할_수_있다() {
         Followers followers = new Followers();
-        User other = new User();
 
-        followers.add(other.getId());
+        followers.add(1L);
 
-        assertThat(followers.contains(other.getId())).isTrue();
+        assertThat(followers.contains(1L)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1, true", "0, false"})
+    void 팔로우_여부를_알_수_있다(Long otherUserId, boolean follows) {
+        Followers followers = new Followers();
+
+        followers.add(1L);
+
+        assertThat(followers.contains(otherUserId)).isEqualTo(follows);
     }
 
     @Test

--- a/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/domain/FollowersTest.java
@@ -1,0 +1,19 @@
+package com.demo.feedsystemdesign.follow.domain;
+
+import com.demo.feedsystemdesign.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FollowersTest {
+
+    @Test
+    void 다른_사용자가_팔로우_할_수_있다() {
+        Followers followers = new Followers();
+        User user = new User();
+
+        followers.add(user.getId());
+
+        assertThat(followers.contains(user.getId())).isTrue();
+    }
+}

--- a/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
@@ -21,4 +21,12 @@ class FollowServiceTest {
 
         assertThat(followService.getFollowers(subjectId)).contains(userId);
     }
+
+    @Test
+    void 어떤_사용자의_팔로워들을_알_수_있다() {
+        followService.follow(2L, 1L);
+        followService.follow(3L, 1L);
+
+        assertThat(followService.getFollowers(1L)).contains(2L, 3L);
+    }
 }

--- a/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
@@ -1,16 +1,23 @@
 package com.demo.feedsystemdesign.follow.service;
 
+import com.demo.feedsystemdesign.common.exception.ErrorCode;
+import com.demo.feedsystemdesign.common.exception.NotFoundException;
+import com.demo.feedsystemdesign.user.domain.User;
+import com.demo.feedsystemdesign.user.domain.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class FollowServiceTest {
 
     @Autowired
     private FollowService followService;
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     void 다른_사용자를_팔로우_할_수_있다() {
@@ -24,9 +31,31 @@ class FollowServiceTest {
 
     @Test
     void 어떤_사용자의_팔로워들을_알_수_있다() {
+        userRepository.save(new User());
+        userRepository.save(new User());
+        userRepository.save(new User());
+
         followService.follow(2L, 1L);
         followService.follow(3L, 1L);
 
         assertThat(followService.getFollowers(1L)).contains(2L, 3L);
+    }
+
+    @Test
+    void 팔로우_대상이_없으면_예외가_발생한다() {
+        User user = userRepository.save(new User());
+
+        assertThatThrownBy(() -> followService.follow(user.getId(), 0L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 팔로우_주체가_없으면_예외가_발생한다() {
+        User user = userRepository.save(new User());
+
+        assertThatThrownBy(() -> followService.follow(0L, user.getId()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
@@ -1,0 +1,24 @@
+package com.demo.feedsystemdesign.follow.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class FollowServiceTest {
+
+    @Autowired
+    private FollowService followService;
+
+    @Test
+    void 다른_사용자를_팔로우_할_수_있다() {
+        Long userId = 1L;
+        Long subjectId = 2L;
+
+        followService.follow(userId, subjectId);
+
+        assertThat(followService.getFollowers(subjectId)).contains(userId);
+    }
+}


### PR DESCRIPTION
## TODO

- UserNotFoundException의 상태 코드는 400일까? 404일까?
- Repository 인터페이스에 default method를 활용해도 될까?
  ```java
  @Repository
  public interface UserRepository extends JpaRepository<User, Long> {
      default User getUserById(Long userId) {
          return findById(userId)
                  .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
      }
  }
  ```
- Followers에서 userId를 primitive type으로 지정할 것인가? wrapper class으로 지정할 것인가?
  - primitive type을 사용할 경우 null safe함. List에 들어갈 때는 wrapper class으로 지정해야 함
  - 때로는 오토 언박싱으로 인한 예상치 못한 문제가 발생할 수 있음
  - 참고: [이펙티브 자바] item 61 - 박싱된 기본 타입보다는 기본 타입을 사용하라