### PR TITLE
feat(feed): 사용자의 피드를 조회한다

### DIFF
--- a/src/main/java/com/demo/feedsystemdesign/feed/domain/Feed.java
+++ b/src/main/java/com/demo/feedsystemdesign/feed/domain/Feed.java
@@ -1,0 +1,17 @@
+package com.demo.feedsystemdesign.feed.domain;
+
+import com.demo.feedsystemdesign.post.domain.Post;
+
+import java.util.List;
+
+public class Feed {
+    private final List<Post> posts;
+
+    public Feed(List<Post> posts) {
+        this.posts = posts;
+    }
+
+    public List<Post> getPosts() {
+        return posts;
+    }
+}

--- a/src/main/java/com/demo/feedsystemdesign/feed/service/FeedService.java
+++ b/src/main/java/com/demo/feedsystemdesign/feed/service/FeedService.java
@@ -1,0 +1,27 @@
+package com.demo.feedsystemdesign.feed.service;
+
+import com.demo.feedsystemdesign.feed.domain.Feed;
+import com.demo.feedsystemdesign.follow.service.FollowService;
+import com.demo.feedsystemdesign.post.domain.Post;
+import com.demo.feedsystemdesign.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class FeedService {
+
+    private final FollowService followService;
+    private final PostService postService;
+
+    public Feed getFeed(Long userId) {
+        List<Long> followers = followService.getFollowings(userId);
+        List<Post> posts = followers.stream()
+                .flatMap(followerId -> postService.getPosts(followerId).stream())
+                .toList();
+        return new Feed(posts);
+    }
+
+}

--- a/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/domain/Followers.java
@@ -9,34 +9,34 @@ import static com.demo.feedsystemdesign.common.exception.ErrorCode.SELF_FOLLOWIN
 
 public class Followers {
 
-    private final Long userId;
+    private final Long ownerId;
     private final List<Long> followers;
 
-    public Followers(Long userId) {
-        this(userId, new ArrayList<>());
+    public Followers(Long ownerId) {
+        this(ownerId, new ArrayList<>());
     }
 
-    public Followers(Long userId, List<Long> followers) {
-        this.userId = userId;
+    public Followers(Long ownerId, List<Long> followers) {
+        this.ownerId = ownerId;
         this.followers = followers;
     }
 
-    public void add(Long otherUserId) {
-        if (userId.equals(otherUserId)) {
+    public void add(Long followerId) {
+        if (ownerId.equals(followerId)) {
             throw new FollowException(SELF_FOLLOWING);
         }
-        followers.add(otherUserId);
+        followers.add(followerId);
     }
 
-    public boolean contains(Long otherUserId) {
-        return followers.contains(otherUserId);
+    public boolean contains(Long followerId) {
+        return followers.contains(followerId);
     }
 
     public List<Long> findAll() {
         return followers;
     }
 
-    public Long getUserId() {
-        return userId;
+    public Long getOwnerId() {
+        return ownerId;
     }
 }

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -15,7 +15,7 @@ import static com.demo.feedsystemdesign.common.exception.ErrorCode.USER_NOT_FOUN
 public class FollowService {
 
     private final UserRepository userRepository;
-    Map<Long, Followers> followersRepository = new HashMap<>();
+    private final Map<Long, Followers> followersRepository = new HashMap<>();
 
     public FollowService(UserRepository userRepository) {
         this.userRepository = userRepository;
@@ -40,7 +40,7 @@ public class FollowService {
     public List<Long> getFollowings(Long userId) {
         return followersRepository.values().stream()
                 .filter(followers -> followers.contains(userId))
-                .map(Followers::getUserId)
+                .map(Followers::getOwnerId)
                 .toList();
     }
 

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -44,7 +44,6 @@ public class FollowService {
                 .toList();
     }
 
-    // TODO: 중복 코드 제거
     private void validateExists(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -37,6 +37,13 @@ public class FollowService {
         return store.get(userId).findAll();
     }
 
+    public List<Long> getFollowings(Long userId) {
+        return store.values().stream()
+                .filter(followers -> followers.contains(userId))
+                .map(Followers::getUserId)
+                .toList();
+    }
+
     // TODO: 중복 코드 제거
     private void validateExists(Long userId) {
         userRepository.findById(userId)

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -15,7 +15,7 @@ import static com.demo.feedsystemdesign.common.exception.ErrorCode.USER_NOT_FOUN
 public class FollowService {
 
     private final UserRepository userRepository;
-    Map<Long, Followers> store = new HashMap<>();
+    Map<Long, Followers> followersRepository = new HashMap<>();
 
     public FollowService(UserRepository userRepository) {
         this.userRepository = userRepository;
@@ -26,19 +26,19 @@ public class FollowService {
         validateExists(userId);
         validateExists(subjectId);
 
-        if (store.get(subjectId) == null) {
-            store.put(subjectId, new Followers(subjectId));
+        if (followersRepository.get(subjectId) == null) {
+            followersRepository.put(subjectId, new Followers(subjectId));
         }
-        Followers followers = store.get(subjectId);
+        Followers followers = followersRepository.get(subjectId);
         followers.add(userId);
     }
 
     public List<Long> getFollowers(Long userId) {
-        return store.get(userId).findAll();
+        return followersRepository.get(userId).findAll();
     }
 
     public List<Long> getFollowings(Long userId) {
-        return store.values().stream()
+        return followersRepository.values().stream()
                 .filter(followers -> followers.contains(userId))
                 .map(Followers::getUserId)
                 .toList();

--- a/src/main/java/com/demo/feedsystemdesign/post/domain/PostRepository.java
+++ b/src/main/java/com/demo/feedsystemdesign/post/domain/PostRepository.java
@@ -3,6 +3,9 @@ package com.demo.feedsystemdesign.post.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/demo/feedsystemdesign/post/service/PostService.java
+++ b/src/main/java/com/demo/feedsystemdesign/post/service/PostService.java
@@ -33,11 +33,8 @@ public class PostService {
                 .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }
 
-    public List<PostResponse> getPosts(Long userId) {
-        return postRepository.findAllByUserId(userId)
-                .stream()
-                .map(PostResponse::of)
-                .toList();
+    public List<Post> getPosts(Long userId) {
+        return postRepository.findAllByUserId(userId);
     }
 
 }

--- a/src/main/java/com/demo/feedsystemdesign/post/service/PostService.java
+++ b/src/main/java/com/demo/feedsystemdesign/post/service/PostService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.demo.feedsystemdesign.common.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
@@ -29,6 +31,13 @@ public class PostService {
     private void validate(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+    }
+
+    public List<PostResponse> getPosts(Long userId) {
+        return postRepository.findAllByUserId(userId)
+                .stream()
+                .map(PostResponse::of)
+                .toList();
     }
 
 }

--- a/src/main/java/com/demo/feedsystemdesign/post/service/dto/PostResponse.java
+++ b/src/main/java/com/demo/feedsystemdesign/post/service/dto/PostResponse.java
@@ -4,9 +4,8 @@ import com.demo.feedsystemdesign.post.domain.Post;
 
 public record PostResponse(
         Long postId,
-        String content,
-        Long userId) {
+        String content) {
     public static PostResponse of(Post post) {
-        return new PostResponse(post.getId(), post.getContent(), post.getUserId());
+        return new PostResponse(post.getId(), post.getContent());
     }
 }

--- a/src/main/java/com/demo/feedsystemdesign/post/service/dto/PostResponse.java
+++ b/src/main/java/com/demo/feedsystemdesign/post/service/dto/PostResponse.java
@@ -4,9 +4,9 @@ import com.demo.feedsystemdesign.post.domain.Post;
 
 public record PostResponse(
         Long postId,
-        String content
-) {
+        String content,
+        Long userId) {
     public static PostResponse of(Post post) {
-        return new PostResponse(post.getId(), post.getContent());
+        return new PostResponse(post.getId(), post.getContent(), post.getUserId());
     }
 }

--- a/src/test/java/com/demo/feedsystemdesign/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/feed/service/FeedServiceTest.java
@@ -48,4 +48,17 @@ public class FeedServiceTest {
         assertThat(feed.getPosts())
                 .allMatch(post -> post.getUserId().equals(subject.getId()));
     }
+
+    @Test
+    void 팔로우_하지_않은_사용자의_게시물은_조회하지_않는다() {
+        User user = userRepository.save(new User());
+        User subject = userRepository.save(new User());
+        postService.createPost(subject.getId(), "test content");
+        postService.createPost(subject.getId(), "test content");
+
+        Feed feed = feedService.getFeed(user.getId());
+
+        assertThat(feed.getPosts())
+                .noneMatch(post -> post.getUserId().equals(subject.getId()));
+    }
 }

--- a/src/test/java/com/demo/feedsystemdesign/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/feed/service/FeedServiceTest.java
@@ -1,0 +1,51 @@
+package com.demo.feedsystemdesign.feed.service;
+
+import com.demo.feedsystemdesign.feed.domain.Feed;
+import com.demo.feedsystemdesign.follow.service.FollowService;
+import com.demo.feedsystemdesign.post.service.PostService;
+import com.demo.feedsystemdesign.user.domain.User;
+import com.demo.feedsystemdesign.user.domain.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class FeedServiceTest {
+
+    @Autowired
+    private FeedService feedService;
+
+    @Autowired
+    private FollowService followService;
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void 사용자의_피드를_가져온다() {
+        User user = userRepository.save(new User());
+
+        Feed feed = feedService.getFeed(user.getId());
+
+        assertThat(feed.getPosts()).isEmpty();
+    }
+
+    @Test
+    void 피드에_팔로우한_사용자의_게시물이_포함된다() {
+        User user = userRepository.save(new User());
+        User subject = userRepository.save(new User());
+        followService.follow(user.getId(), subject.getId());
+        postService.createPost(subject.getId(), "test content");
+        postService.createPost(subject.getId(), "test content");
+
+        Feed feed = feedService.getFeed(user.getId());
+
+        assertThat(feed.getPosts())
+                .allMatch(post -> post.getUserId().equals(subject.getId()));
+    }
+}

--- a/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
@@ -8,8 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 class FollowServiceTest {
@@ -19,6 +20,7 @@ class FollowServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    // TODO: 테스트 격리
     @Test
     void 다른_사용자를_팔로우_할_수_있다() {
         Long userId = 1L;
@@ -29,6 +31,7 @@ class FollowServiceTest {
         assertThat(followService.getFollowers(subjectId)).contains(userId);
     }
 
+    // TODO: id를 직관적으로 사용
     @Test
     void 어떤_사용자의_팔로워들을_알_수_있다() {
         userRepository.save(new User());
@@ -58,4 +61,19 @@ class FollowServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void 사용자가_팔로우_하고_있는_사용자들을_반환한다() {
+        User user = userRepository.save(new User());
+        User follower1 = userRepository.save(new User());
+        User follower2 = userRepository.save(new User());
+
+        followService.follow(user.getId(), follower1.getId());
+        followService.follow(user.getId(), follower2.getId());
+
+        List<Long> followingIds = followService.getFollowings(user.getId());
+
+        assertThat(followingIds).containsExactly(follower1.getId(), follower2.getId());
+    }
+
 }

--- a/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/follow/service/FollowServiceTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
@@ -20,28 +18,28 @@ class FollowServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    // TODO: 테스트 격리
     @Test
     void 다른_사용자를_팔로우_할_수_있다() {
-        Long userId = 1L;
-        Long subjectId = 2L;
+        User user = userRepository.save(new User());
+        User subject = userRepository.save(new User());
 
-        followService.follow(userId, subjectId);
+        followService.follow(user.getId(), subject.getId());
 
-        assertThat(followService.getFollowers(subjectId)).contains(userId);
+        assertThat(followService.getFollowers(subject.getId()))
+                .containsExactly(user.getId());
     }
 
-    // TODO: id를 직관적으로 사용
     @Test
     void 어떤_사용자의_팔로워들을_알_수_있다() {
-        userRepository.save(new User());
-        userRepository.save(new User());
-        userRepository.save(new User());
+        User user = userRepository.save(new User());
+        User subject = userRepository.save(new User());
+        User otherSubject = userRepository.save(new User());
 
-        followService.follow(2L, 1L);
-        followService.follow(3L, 1L);
+        followService.follow(subject.getId(), user.getId());
+        followService.follow(otherSubject.getId(), user.getId());
 
-        assertThat(followService.getFollowers(1L)).contains(2L, 3L);
+        assertThat(followService.getFollowers(user.getId()))
+                .containsExactly(subject.getId(), otherSubject.getId());
     }
 
     @Test
@@ -65,15 +63,14 @@ class FollowServiceTest {
     @Test
     void 사용자가_팔로우_하고_있는_사용자들을_반환한다() {
         User user = userRepository.save(new User());
-        User follower1 = userRepository.save(new User());
-        User follower2 = userRepository.save(new User());
+        User follower = userRepository.save(new User());
+        User otherFollower = userRepository.save(new User());
 
-        followService.follow(user.getId(), follower1.getId());
-        followService.follow(user.getId(), follower2.getId());
+        followService.follow(user.getId(), follower.getId());
+        followService.follow(user.getId(), otherFollower.getId());
 
-        List<Long> followingIds = followService.getFollowings(user.getId());
-
-        assertThat(followingIds).containsExactly(follower1.getId(), follower2.getId());
+        assertThat(followService.getFollowings(user.getId()))
+                .containsExactly(follower.getId(), otherFollower.getId());
     }
 
 }

--- a/src/test/java/com/demo/feedsystemdesign/post/domain/PostTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/post/domain/PostTest.java
@@ -5,7 +5,6 @@ import com.demo.feedsystemdesign.common.exception.PostContentLengthException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("NonAsciiCharacters")
 class PostTest {
 
     @Test

--- a/src/test/java/com/demo/feedsystemdesign/post/service/PostServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/post/service/PostServiceTest.java
@@ -39,4 +39,19 @@ class PostServiceTest {
 
         assertThat(post.content()).isEqualTo(content);
     }
+
+    @Test
+    void 사용자의_모든_게시물을_조회한다() {
+        User user = userRepository.save(new User());
+
+        PostResponse post = postService.createPost(user.getId(), "test content");
+
+        assertThat(postService.getPosts(user.getId()))
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.content()).isEqualTo(post.content());
+                    assertThat(result.userId()).isEqualTo(user.getId());
+                });
+    }
+
 }

--- a/src/test/java/com/demo/feedsystemdesign/post/service/PostServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/post/service/PostServiceTest.java
@@ -49,8 +49,8 @@ class PostServiceTest {
         assertThat(postService.getPosts(user.getId()))
                 .singleElement()
                 .satisfies(result -> {
-                    assertThat(result.content()).isEqualTo(post.content());
-                    assertThat(result.userId()).isEqualTo(user.getId());
+                    assertThat(result.getContent()).isEqualTo(post.content());
+                    assertThat(result.getUserId()).isEqualTo(user.getId());
                 });
     }
 

--- a/src/test/java/com/demo/feedsystemdesign/post/service/PostServiceTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/post/service/PostServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest
 class PostServiceTest {
 


### PR DESCRIPTION
### TODO
- [x] FollowService의 store 변수명이 직관적이지 않음
- [x] Followers의 userId 변수 명이 직관적이지 않음
- [ ] 팔로우 관계를 DB에 영속화 해야 한다