### PR TITLE
refactor(follow): primitive long을 걷어낸다

### DIFF
--- a/src/main/java/com/demo/feedsystemdesign/follow/domain/Follow.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/domain/Follow.java
@@ -2,12 +2,13 @@ package com.demo.feedsystemdesign.follow.domain;
 
 import com.demo.feedsystemdesign.common.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends BaseTimeEntity {
 
     @Id
@@ -15,10 +16,10 @@ public class Follow extends BaseTimeEntity {
     @Column(name = "follow_id")
     private Long id;
 
-    private long sourceId;
-    private long targetId;
+    private Long sourceId;
+    private Long targetId;
 
-    public Follow(long sourceId, long targetId) {
+    public Follow(Long sourceId, Long targetId) {
         this.sourceId = sourceId;
         this.targetId = targetId;
     }

--- a/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
+++ b/src/main/java/com/demo/feedsystemdesign/follow/service/FollowService.java
@@ -20,28 +20,28 @@ public class FollowService {
     private final FollowRepository followRepository;
 
     @Transactional
-    public void follow(long sourceId, long targetId) {
+    public void follow(Long sourceId, Long targetId) {
         validateExists(sourceId);
         validateExists(targetId);
 
         followRepository.save(new Follow(sourceId, targetId));
     }
 
-    public List<Long> getFollowers(long userId) {
+    public List<Long> getFollowers(Long userId) {
         return followRepository.findAllByTargetId(userId)
                 .stream()
                 .map(Follow::getSourceId)
                 .toList();
     }
 
-    public List<Long> getFollowings(long userId) {
+    public List<Long> getFollowings(Long userId) {
         return followRepository.findAllBySourceId(userId)
                 .stream()
                 .map(Follow::getTargetId)
                 .toList();
     }
 
-    private void validateExists(long userId) {
+    private void validateExists(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
     }

--- a/src/test/java/com/demo/feedsystemdesign/study/PrimitiveTypeTest.java
+++ b/src/test/java/com/demo/feedsystemdesign/study/PrimitiveTypeTest.java
@@ -1,0 +1,42 @@
+package com.demo.feedsystemdesign.study;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PrimitiveTypeTest {
+
+    @Test
+    void long은_지역_내에서_값을_할당하지_않으면_컴파일_에러가_발생한다() {
+        long a;
+
+//        System.out.println("a = " + a); // 에러 발생
+    }
+
+    @Test
+    void 그러나_객체의_필드로_long을_사용하면_0으로_초기화된다() {
+        class PrimitiveLongClass {
+            long a;
+        }
+
+        PrimitiveLongClass testInstance = new PrimitiveLongClass();
+
+        assertThat(testInstance.a).isZero();
+        // 0으로 초기화되는 것은 의도와 다르다.
+        // 더 정확한 제어를 위해서는 null이 들어가서 오류가 발생하는 편이 낫다.
+    }
+
+    @Test
+    void 따라서_0을_기본값으로_사용하고_싶은_것이_아니라면_Long이_더_안전할수도_있다() {
+        class ReferenceLongClass {
+            Long a;
+        }
+
+        ReferenceLongClass testInstance = new ReferenceLongClass();
+
+        assertThat(testInstance.a).isNull();
+    }
+}


### PR DESCRIPTION
### 고민
Null을 허용하지 않기 위해 primitive type을 사용했다.
long의 기본 값은 0이고, Long의 기본 값은 null 이다. 우연히 휴먼 에러로 인해 0이나 null 이 들어갈 수도 있다.
다른 값(0)이 들어가는 문제 vs NPE가 발생하는 문제 중에 어느 것이 더 심각한 오류일까?

### 결론
DB에 0이 들어가 있다면, 오류를 발생하지 않고 의도와 다르게 동작할 수 있다. 차라리 null 이 낫다.
객체를 기본 생성자로 만들면 sourceId, targetId을 0으로 할당된다. 따라서 Follow 객체에 long을 사용하는 것은 위험하다. 